### PR TITLE
Refine core state machines

### DIFF
--- a/primus-core/src/main/java/com/bytedance/primus/am/container/ContainerManagerEventType.java
+++ b/primus-core/src/main/java/com/bytedance/primus/am/container/ContainerManagerEventType.java
@@ -22,6 +22,7 @@ package com.bytedance.primus.am.container;
 public enum ContainerManagerEventType {
   EXECUTOR_EXPIRED,
   GRACEFUL_SHUTDOWN,
+  FORCIBLY_SHUTDOWN,
   CONTAINER_REQUEST_CREATED,
   CONTAINER_REQUEST_UPDATED,
 }

--- a/primus-core/src/main/java/com/bytedance/primus/am/schedulerexecutor/SchedulerExecutorEventType.java
+++ b/primus-core/src/main/java/com/bytedance/primus/am/schedulerexecutor/SchedulerExecutorEventType.java
@@ -28,5 +28,6 @@ public enum SchedulerExecutorEventType {
   RELEASED,
   BLACKLIST,
   KILL,
+  KILL_FORCIBLY, // Instruct executor to quit without serving graceful shutdown time wait.
   KILLED,
 }

--- a/primus-core/src/main/java/com/bytedance/primus/am/schedulerexecutor/SchedulerExecutorImpl.java
+++ b/primus-core/src/main/java/com/bytedance/primus/am/schedulerexecutor/SchedulerExecutorImpl.java
@@ -163,6 +163,26 @@ public class SchedulerExecutorImpl implements SchedulerExecutor {
               SchedulerExecutorState.RELEASED,
               SchedulerExecutorEventType.KILL)
 
+          // TODO: Streamline core state machines
+          .addTransition(SchedulerExecutorState.NEW,
+              SchedulerExecutorState.KILLING_FORCIBLY,
+              SchedulerExecutorEventType.KILL_FORCIBLY)
+          .addTransition(SchedulerExecutorState.STARTING,
+              SchedulerExecutorState.KILLING_FORCIBLY,
+              SchedulerExecutorEventType.KILL_FORCIBLY)
+          .addTransition(SchedulerExecutorState.RUNNING,
+              SchedulerExecutorState.KILLING_FORCIBLY,
+              SchedulerExecutorEventType.KILL_FORCIBLY)
+          .addTransition(SchedulerExecutorState.FAILED,
+              SchedulerExecutorState.FAILED,
+              SchedulerExecutorEventType.KILL_FORCIBLY)
+          .addTransition(SchedulerExecutorState.COMPLETED,
+              SchedulerExecutorState.COMPLETED,
+              SchedulerExecutorEventType.KILL_FORCIBLY)
+          .addTransition(SchedulerExecutorState.RELEASED,
+              SchedulerExecutorState.RELEASED,
+              SchedulerExecutorEventType.KILL_FORCIBLY)
+
           .addTransition(SchedulerExecutorState.KILLING,
               SchedulerExecutorState.KILLING,
               SchedulerExecutorEventType.REGISTERED)
@@ -174,6 +194,10 @@ public class SchedulerExecutorImpl implements SchedulerExecutor {
               SchedulerExecutorEventType.KILLED,
               new KilledTransition())
           .addTransition(SchedulerExecutorState.KILLING,
+              SchedulerExecutorState.KILLED,
+              SchedulerExecutorEventType.KILLED,
+              new KilledTransition())
+          .addTransition(SchedulerExecutorState.KILLING_FORCIBLY,
               SchedulerExecutorState.KILLED,
               SchedulerExecutorEventType.KILLED,
               new KilledTransition())

--- a/primus-core/src/main/java/com/bytedance/primus/am/schedulerexecutor/SchedulerExecutorManagerEventType.java
+++ b/primus-core/src/main/java/com/bytedance/primus/am/schedulerexecutor/SchedulerExecutorManagerEventType.java
@@ -26,4 +26,5 @@ public enum SchedulerExecutorManagerEventType {
   EXECUTOR_REQUEST_CREATED,
   EXECUTOR_REQUEST_UPDATED,
   EXECUTOR_KILL,
+  EXECUTOR_KILL_FORCIBLY, // Instruct executor to quit without serving graceful shutdown time wait.
 }

--- a/primus-core/src/main/java/com/bytedance/primus/am/schedulerexecutor/SchedulerExecutorState.java
+++ b/primus-core/src/main/java/com/bytedance/primus/am/schedulerexecutor/SchedulerExecutorState.java
@@ -28,5 +28,6 @@ public enum SchedulerExecutorState {
   COMPLETED,
   RELEASED,
   KILLING,
+  KILLING_FORCIBLY, // Instruct executor to quit without serving graceful shutdown time wait.
   KILLED,
 }

--- a/primus-core/src/main/java/com/bytedance/primus/api/records/ExecutorState.java
+++ b/primus-core/src/main/java/com/bytedance/primus/api/records/ExecutorState.java
@@ -25,6 +25,7 @@ public enum ExecutorState {
   STARTING,
   RUNNING,
   KILLING,
+  KILLING_FORCIBLY, // XXX: A hotfix for an YARN deployment, have to standardize to Kubernetes
   RECOVERING,
   EXITED_WITH_FAILURE,
   EXITED_WITH_SUCCESS,

--- a/primus-core/src/main/java/com/bytedance/primus/executor/ExecutorContext.java
+++ b/primus-core/src/main/java/com/bytedance/primus/executor/ExecutorContext.java
@@ -20,6 +20,7 @@
 package com.bytedance.primus.executor;
 
 import com.bytedance.primus.api.records.ExecutorId;
+import com.bytedance.primus.api.records.ExecutorState;
 import com.bytedance.primus.apiserver.proto.ResourceProto.ConsulConfig;
 import com.bytedance.primus.common.child.ChildLauncher;
 import com.bytedance.primus.common.event.Dispatcher;
@@ -29,10 +30,12 @@ import com.bytedance.primus.common.network.NetworkConfig;
 import com.bytedance.primus.executor.environment.RunningEnvironment;
 import com.bytedance.primus.executor.task.TaskRunnerManager;
 import com.bytedance.primus.executor.task.WorkerFeeder;
+import com.bytedance.primus.proto.PrimusConfOuterClass.PrimusConf;
 import com.bytedance.primus.utils.timeline.TimelineLogger;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.List;
 import lombok.Getter;
 import org.apache.hadoop.fs.FileSystem;
@@ -202,5 +205,12 @@ public class ExecutorContext {
 
   public void setRunning(boolean running) {
     this.running = running;
+  }
+
+  public Duration getGracefulShutdownDuration() {
+    PrimusConf primusConf = getPrimusExecutorConf().getPrimusConf();
+    return executor.getExecutorState() != ExecutorState.KILLING_FORCIBLY
+        ? Duration.ofMinutes(primusConf.getGracefulShutdownTimeoutMin())
+        : Duration.ZERO;
   }
 }

--- a/primus-core/src/main/java/com/bytedance/primus/executor/ExecutorEventType.java
+++ b/primus-core/src/main/java/com/bytedance/primus/executor/ExecutorEventType.java
@@ -24,6 +24,7 @@ public enum ExecutorEventType {
   START,
   REGISTERED,
   KILL,
+  KILL_FORCIBLY,
 
   // producer : com.bytedance.primus.executor.worker
   STARTED,

--- a/primus-core/src/main/java/com/bytedance/primus/executor/ExecutorImpl.java
+++ b/primus-core/src/main/java/com/bytedance/primus/executor/ExecutorImpl.java
@@ -151,6 +151,10 @@ public class ExecutorImpl implements Executor {
               ExecutorState.EXITED_WITH_SUCCESS,
               ExecutorEventType.SUCCEEDED,
               new SucceededTransition())
+          .addTransition(ExecutorState.KILLING_FORCIBLY,
+              ExecutorState.EXITED_WITH_KILLED,
+              ExecutorEventType.KILLED,
+              new KilledTransition())
           .addTransition(ExecutorState.EXITED_WITH_SUCCESS,
               ExecutorState.EXITED_WITH_SUCCESS,
               ExecutorEventType.KILL)
@@ -163,6 +167,45 @@ public class ExecutorImpl implements Executor {
           .addTransition(ExecutorState.EXITED_WITH_KILLED,
               ExecutorState.EXITED_WITH_KILLED,
               ExecutorEventType.KILL)
+
+          // TODO: Streamline core state machines
+          .addTransition(ExecutorState.NEW,
+              ExecutorState.KILLING_FORCIBLY,
+              ExecutorEventType.KILL_FORCIBLY,
+              new KillingForciblyTransition())
+          .addTransition(ExecutorState.REGISTERED,
+              ExecutorState.KILLING_FORCIBLY,
+              ExecutorEventType.KILL_FORCIBLY,
+              new KillingForciblyTransition())
+          .addTransition(ExecutorState.STARTING,
+              ExecutorState.KILLING_FORCIBLY,
+              ExecutorEventType.KILL_FORCIBLY,
+              new KillingForciblyTransition())
+          .addTransition(ExecutorState.RUNNING,
+              ExecutorState.KILLING_FORCIBLY,
+              ExecutorEventType.KILL_FORCIBLY,
+              new KillingForciblyTransition())
+          .addTransition(ExecutorState.KILLING,
+              ExecutorState.KILLING_FORCIBLY,
+              ExecutorEventType.KILL_FORCIBLY,
+              new KillingForciblyTransition())
+          .addTransition(ExecutorState.KILLING_FORCIBLY,
+              ExecutorState.KILLING_FORCIBLY,
+              ExecutorEventType.KILL_FORCIBLY)
+          .addTransition(ExecutorState.RECOVERING,
+              ExecutorState.KILLING_FORCIBLY,
+              ExecutorEventType.KILL_FORCIBLY,
+              new KillingForciblyTransition())
+          .addTransition(ExecutorState.EXITED_WITH_FAILURE,
+              ExecutorState.EXITED_WITH_FAILURE,
+              ExecutorEventType.KILL_FORCIBLY)
+          .addTransition(ExecutorState.EXITED_WITH_SUCCESS,
+              ExecutorState.EXITED_WITH_SUCCESS,
+              ExecutorEventType.KILL_FORCIBLY)
+          .addTransition(ExecutorState.EXITED_WITH_KILLED,
+              ExecutorState.EXITED_WITH_KILLED,
+              ExecutorEventType.KILL_FORCIBLY)
+
           .installTopology();
 
   private final StateMachine<ExecutorState, ExecutorEventType, ExecutorEvent> stateMachine;
@@ -255,6 +298,23 @@ public class ExecutorImpl implements Executor {
       LOG.info("Executor[" + executor.executorContext.getExecutorId() + "] begin to stopProcess");
       executor.dispatcher.getEventHandler()
           .handle(new TaskRunnerManagerEvent(TaskRunnerManagerEventType.TASK_REMOVE_ALL,
+              executor.getExecutorId()));
+    }
+  }
+
+  static class KillingForciblyTransition implements
+      SingleArcTransition<ExecutorImpl, ExecutorEvent> {
+
+    @Override
+    public void transition(ExecutorImpl executor, ExecutorEvent event) {
+      LOG.info(
+          "Executor[{}] begin to stopProcess forcibly",
+          executor.executorContext.getExecutorId());
+      // TODO: Streamline core state machines
+      executor.dispatcher
+          .getEventHandler()
+          .handle(new TaskRunnerManagerEvent(
+              TaskRunnerManagerEventType.TASK_REMOVE_ALL,
               executor.getExecutorId()));
     }
   }

--- a/primus-core/src/main/java/com/bytedance/primus/utils/PrimusConstants.java
+++ b/primus-core/src/main/java/com/bytedance/primus/utils/PrimusConstants.java
@@ -63,6 +63,8 @@ public class PrimusConstants {
 
   public static final int SCAN_INTERVAL_HOUR = 6;
 
-  public static final int UPDATE_TO_API_SERVER_RETRY_TIMES = 3;
+  // Since the new state machine incurs more updates to API server and thus more occurrences
+  // of mismatched versions, this threshold is increased.
+  public static final int UPDATE_TO_API_SERVER_RETRY_TIMES = 10;
   public static final int UPDATE_TO_API_SERVER_RETRY_INTERVAL_MS = 2000;
 }

--- a/runtime/runtime-yarn-community/src/main/java/com/bytedance/primus/runtime/yarncommunity/am/container/scheduler/fair/FairContainerManager.java
+++ b/runtime/runtime-yarn-community/src/main/java/com/bytedance/primus/runtime/yarncommunity/am/container/scheduler/fair/FairContainerManager.java
@@ -102,9 +102,9 @@ public class FairContainerManager extends YarnContainerManager {
 
       int completedNum = schedulerExecutorManager.getCompletedNum(priority);
       int replicas = roleInfo.getRoleSpec().getReplicas();
-      if (containerIds.size() + completedNum >= replicas || gracefulShutdown) {
+      if (containerIds.size() + completedNum >= replicas || isShuttingDown) {
         LOG.info("Enough role: " + roleInfo.getRoleName() + ", num: " + containerIds.size()
-            + ", graceful shutdown: " + gracefulShutdown);
+            + ", graceful shutdown: " + isShuttingDown);
         amRMClient.releaseAssignedContainer(container.getId());
         amRMClient.removeContainerRequest(roleInfo.getContainerRequest());
         PrimusMetrics.emitCounterWithAppIdTag(


### PR DESCRIPTION
This MR contains commits refining Primus core state machines to better handle the following cases respectively.
1. Always start workers even if there is no task assigned for serving training frameworks using worker[0] as chief.
2. Skip grace shutdown time wait during gang failure to shorten overall application quit time wait.