### PR TITLE
Link to Monolith example

### DIFF
--- a/docs/primus-overview.md
+++ b/docs/primus-overview.md
@@ -1,8 +1,11 @@
 # Primus - Overview
 
 Primus is a generic distributed scheduling framework for machine learning applications, which
-manages training lifecycles and data distribution for machine learning trainers such as
-TensorFlow to perform distributed training in massive scales.
+manages training lifecycles and data distribution for machine learning trainers such
+as [Monolith](https://github.com/bytedance/monolith)
+and [TensorFlow](https://github.com/tensorflow/tensorflow)
+to perform distributed training in massive
+scales.
 
 Given the intrinsic uncertainties in distributed environments, distributed trainings are inevitably
 complicated. Abstracting many of those complications, Primus provides a robust solution for data

--- a/examples/monolith/README.md
+++ b/examples/monolith/README.md
@@ -1,0 +1,12 @@
+Primus also works well with ByteDance [Monolith](https://github.com/bytedance/monolith), please
+refer to [Primus Example](https://github.com/bytedance/monolith/tree/master/markdown/primus_demo)
+from Monolith to see how Primus on Kubernetes is integrated with Monolith.
+
+Notes
+
+- Setting up [Primus Baseline VM](../../docs/primus-quickstart.md) on bare-metal Ubuntu 22.04 is
+  suggested, since some hypervisors such as VirtualBox hinder CPU instruction sets required by
+  Monolith prebuilt docker image.
+- 20+ GB memory is required for the machine to host Monolith example.
+- Increasing `"registerRetryTimes"` in Primus Configuration to 900 is encouraged as Monolith
+  prebuilt docker image takes longer to launch.  


### PR DESCRIPTION
Link to the example residing in ByteDance monolith for demonstrating how Monolith integrates with Primus on Kubernetes.